### PR TITLE
Apply rustfmt formatting

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -8,7 +8,7 @@ use petgraph::stable_graph::{NodeIndex, StableGraph};
 
 use crate::error::ChronicleError;
 use crate::model::*;
-use crate::validation::{ValidationReport, ValidationError, validate, can_add_event};
+use crate::validation::{ValidationError, ValidationReport, can_add_event, validate};
 
 /// The core chronicle graph.
 ///
@@ -75,7 +75,11 @@ impl Chronicle {
         load_dir::<Concept>(path, "concepts", &mut graph, &mut index)?;
         load_dir::<Account>(path, "accounts", &mut graph, &mut index)?;
 
-        let mut chronicle = Self { graph, index, config };
+        let mut chronicle = Self {
+            graph,
+            index,
+            config,
+        };
         chronicle.build_edges();
         Ok(chronicle)
     }
@@ -143,11 +147,7 @@ impl Chronicle {
                     }
                 }
                 Entity::Account(account) => {
-                    edges.push((
-                        nx,
-                        account.source.clone(),
-                        Relationship::AuthoredBy,
-                    ));
+                    edges.push((nx, account.source.clone(), Relationship::AuthoredBy));
                     for ev in &account.event_refs {
                         edges.push((nx, ev.clone(), Relationship::AccountOf));
                     }
@@ -206,30 +206,60 @@ trait IntoEntity {
 }
 
 impl IntoEntity for Actor {
-    fn into_entity(self) -> Entity { Entity::Actor(self) }
+    fn into_entity(self) -> Entity {
+        Entity::Actor(self)
+    }
 }
 impl IntoEntity for Place {
-    fn into_entity(self) -> Entity { Entity::Place(self) }
+    fn into_entity(self) -> Entity {
+        Entity::Place(self)
+    }
 }
 impl IntoEntity for Event {
-    fn into_entity(self) -> Entity { Entity::Event(self) }
+    fn into_entity(self) -> Entity {
+        Entity::Event(self)
+    }
 }
 impl IntoEntity for Concept {
-    fn into_entity(self) -> Entity { Entity::Concept(self) }
+    fn into_entity(self) -> Entity {
+        Entity::Concept(self)
+    }
 }
 impl IntoEntity for Account {
-    fn into_entity(self) -> Entity { Entity::Account(self) }
+    fn into_entity(self) -> Entity {
+        Entity::Account(self)
+    }
 }
 
 trait HasId {
     fn id(&self) -> &str;
 }
 
-impl HasId for Actor { fn id(&self) -> &str { &self.id } }
-impl HasId for Place { fn id(&self) -> &str { &self.id } }
-impl HasId for Event { fn id(&self) -> &str { &self.id } }
-impl HasId for Concept { fn id(&self) -> &str { &self.id } }
-impl HasId for Account { fn id(&self) -> &str { &self.id } }
+impl HasId for Actor {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+impl HasId for Place {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+impl HasId for Event {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+impl HasId for Concept {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
+impl HasId for Account {
+    fn id(&self) -> &str {
+        &self.id
+    }
+}
 
 fn load_dir<T>(
     root: &Path,

--- a/src/query.rs
+++ b/src/query.rs
@@ -38,7 +38,10 @@ impl Chronicle {
     pub fn actor(&self, id: &str) -> Option<ActorQuery<'_>> {
         let &nx = self.index.get(id)?;
         match &self.graph[nx] {
-            Entity::Actor(_) => Some(ActorQuery { chronicle: self, nx }),
+            Entity::Actor(_) => Some(ActorQuery {
+                chronicle: self,
+                nx,
+            }),
             _ => None,
         }
     }
@@ -49,7 +52,10 @@ impl Chronicle {
     pub fn event(&self, id: &str) -> Option<EventQuery<'_>> {
         let &nx = self.index.get(id)?;
         match &self.graph[nx] {
-            Entity::Event(_) => Some(EventQuery { chronicle: self, nx }),
+            Entity::Event(_) => Some(EventQuery {
+                chronicle: self,
+                nx,
+            }),
             _ => None,
         }
     }
@@ -60,7 +66,10 @@ impl Chronicle {
     pub fn place(&self, id: &str) -> Option<PlaceQuery<'_>> {
         let &nx = self.index.get(id)?;
         match &self.graph[nx] {
-            Entity::Place(_) => Some(PlaceQuery { chronicle: self, nx }),
+            Entity::Place(_) => Some(PlaceQuery {
+                chronicle: self,
+                nx,
+            }),
             _ => None,
         }
     }
@@ -71,14 +80,19 @@ impl Chronicle {
     pub fn concept(&self, id: &str) -> Option<ConceptQuery<'_>> {
         let &nx = self.index.get(id)?;
         match &self.graph[nx] {
-            Entity::Concept(_) => Some(ConceptQuery { chronicle: self, nx }),
+            Entity::Concept(_) => Some(ConceptQuery {
+                chronicle: self,
+                nx,
+            }),
             _ => None,
         }
     }
 
     /// All accounts whose text contains a `{entity_id}` reference to this entity.
     pub fn mentions(&self, entity_id: &str) -> Vec<&Account> {
-        let Some(&target_nx) = self.index.get(entity_id) else { return vec![] };
+        let Some(&target_nx) = self.index.get(entity_id) else {
+            return vec![];
+        };
         let mut seen = HashSet::new();
         self.neighbors_by_edge(target_nx, Direction::Incoming, |r| {
             matches!(r, Relationship::Mentions)
@@ -94,7 +108,9 @@ impl Chronicle {
 
     /// All accounts that reference this event (via AccountOf edges).
     pub fn accounts_of(&self, event_id: &str) -> Vec<&Account> {
-        let Some(&target_nx) = self.index.get(event_id) else { return vec![] };
+        let Some(&target_nx) = self.index.get(event_id) else {
+            return vec![];
+        };
         let mut seen = HashSet::new();
         self.neighbors_by_edge(target_nx, Direction::Incoming, |r| {
             matches!(r, Relationship::AccountOf)
@@ -110,7 +126,9 @@ impl Chronicle {
 
     /// All accounts authored by a given source.
     pub fn accounts_by(&self, source_id: &str) -> Vec<&Account> {
-        let Some(&source_nx) = self.index.get(source_id) else { return vec![] };
+        let Some(&source_nx) = self.index.get(source_id) else {
+            return vec![];
+        };
         let mut seen = HashSet::new();
         self.neighbors_by_edge(source_nx, Direction::Incoming, |r| {
             matches!(r, Relationship::AuthoredBy)
@@ -213,12 +231,20 @@ impl<'a> InteractionResult<'a> {
 
     /// Returns only actors of type [`ActorType::Character`].
     pub fn people(&self) -> Vec<&'a Actor> {
-        self.actors.iter().filter(|a| a.actor_type == ActorType::Character).copied().collect()
+        self.actors
+            .iter()
+            .filter(|a| a.actor_type == ActorType::Character)
+            .copied()
+            .collect()
     }
 
     /// Returns only actors of type [`ActorType::Faction`].
     pub fn factions(&self) -> Vec<&'a Actor> {
-        self.actors.iter().filter(|a| a.actor_type == ActorType::Faction).copied().collect()
+        self.actors
+            .iter()
+            .filter(|a| a.actor_type == ActorType::Faction)
+            .copied()
+            .collect()
     }
 }
 
@@ -249,7 +275,11 @@ impl<'a> EventQuery<'a> {
 
     /// Participants filtered by role.
     pub fn participants_by_role(&self, role: Role) -> Vec<&'a Participant> {
-        self.data().participants.iter().filter(|p| p.role == role).collect()
+        self.data()
+            .participants
+            .iter()
+            .filter(|p| p.role == role)
+            .collect()
     }
 
     /// The location of this event, if any.
@@ -442,5 +472,8 @@ fn status_at_impl(chronicle: &Chronicle, entity_id: &str, year: i32) -> Status {
     }
 
     changes.sort_by_key(|(time, _)| *time);
-    changes.last().map(|(_, s)| (*s).clone()).unwrap_or(Status::Active)
+    changes
+        .last()
+        .map(|(_, s)| (*s).clone())
+        .unwrap_or(Status::Active)
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -86,14 +86,35 @@ pub enum ValidationWarning {
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::DanglingReference { source_id, target_id, context } => {
-                write!(f, "dangling reference: {source_id} -> {target_id} ({context})")
+            Self::DanglingReference {
+                source_id,
+                target_id,
+                context,
+            } => {
+                write!(
+                    f,
+                    "dangling reference: {source_id} -> {target_id} ({context})"
+                )
             }
-            Self::TemporalViolation { entity_id, event_id, description } => {
-                write!(f, "temporal violation: {entity_id} in {event_id}: {description}")
+            Self::TemporalViolation {
+                entity_id,
+                event_id,
+                description,
+            } => {
+                write!(
+                    f,
+                    "temporal violation: {entity_id} in {event_id}: {description}"
+                )
             }
-            Self::StateViolation { entity_id, event_id, description } => {
-                write!(f, "state violation: {entity_id} in {event_id}: {description}")
+            Self::StateViolation {
+                entity_id,
+                event_id,
+                description,
+            } => {
+                write!(
+                    f,
+                    "state violation: {entity_id} in {event_id}: {description}"
+                )
             }
         }
     }
@@ -165,7 +186,13 @@ fn validate_referential(chronicle: &Chronicle, report: &mut ValidationReport) {
                     check_ref(chronicle, &event.id, &p.actor, "participant", report);
                 }
                 for sc in &event.state_changes {
-                    check_ref(chronicle, &event.id, &sc.entity, "state_change target", report);
+                    check_ref(
+                        chronicle,
+                        &event.id,
+                        &sc.entity,
+                        "state_change target",
+                        report,
+                    );
                 }
             }
             Entity::Concept(concept) => {
@@ -206,7 +233,12 @@ fn check_ref(
 
 fn to_interval(ts: &TimeSpan) -> Option<NonEmpty<Interval<i32>>> {
     // TimeSpan uses inclusive bounds; Allen's discrete intervals use exclusive end.
-    Interval { start: ts.start, end: ts.end + 1 }.try_into().ok()
+    Interval {
+        start: ts.start,
+        end: ts.end + 1,
+    }
+    .try_into()
+    .ok()
 }
 
 /// True if interval `a` ends strictly before `b` starts (precedes or meets in Allen's algebra).
@@ -217,7 +249,9 @@ fn strictly_before(a: &NonEmpty<Interval<i32>>, b: &NonEmpty<Interval<i32>>) -> 
 fn validate_temporal(chronicle: &Chronicle, report: &mut ValidationReport) {
     for nx in chronicle.graph.node_indices() {
         if let Entity::Event(event) = &chronicle.graph[nx] {
-            let Some(event_iv) = to_interval(&event.time_span) else { continue };
+            let Some(event_iv) = to_interval(&event.time_span) else {
+                continue;
+            };
 
             // Check participants' lifespans
             for p in &event.participants {
@@ -232,8 +266,10 @@ fn validate_temporal(chronicle: &Chronicle, report: &mut ValidationReport) {
                             event_id: event.id.clone(),
                             description: format!(
                                 "event at {}-{} precedes actor lifespan {}-{}",
-                                event.time_span.start, event.time_span.end,
-                                lifespan.start, lifespan.end,
+                                event.time_span.start,
+                                event.time_span.end,
+                                lifespan.start,
+                                lifespan.end,
                             ),
                         });
                     }
@@ -243,8 +279,10 @@ fn validate_temporal(chronicle: &Chronicle, report: &mut ValidationReport) {
                             event_id: event.id.clone(),
                             description: format!(
                                 "actor lifespan {}-{} ends before event at {}-{}",
-                                lifespan.start, lifespan.end,
-                                event.time_span.start, event.time_span.end,
+                                lifespan.start,
+                                lifespan.end,
+                                event.time_span.start,
+                                event.time_span.end,
                             ),
                         });
                     }
@@ -263,8 +301,10 @@ fn validate_temporal(chronicle: &Chronicle, report: &mut ValidationReport) {
                         event_id: cause_event.id.clone(),
                         description: format!(
                             "effect {}-{} precedes its cause {}-{}",
-                            event.time_span.start, event.time_span.end,
-                            cause_event.time_span.start, cause_event.time_span.end,
+                            event.time_span.start,
+                            event.time_span.end,
+                            cause_event.time_span.start,
+                            cause_event.time_span.end,
                         ),
                     });
                     // cause precedes/meets effect = valid; overlap/equal = ambiguous, not error
@@ -281,7 +321,9 @@ fn validate_state(chronicle: &Chronicle, config: &ValidationConfig, report: &mut
 
     for nx in chronicle.graph.node_indices() {
         if let Entity::Event(event) = &chronicle.graph[nx] {
-            let Some(event_iv) = to_interval(&event.time_span) else { continue };
+            let Some(event_iv) = to_interval(&event.time_span) else {
+                continue;
+            };
 
             // Check participants aren't in a terminal state from a strictly earlier event
             for p in &event.participants {
@@ -297,9 +339,14 @@ fn validate_state(chronicle: &Chronicle, config: &ValidationConfig, report: &mut
                             description: format!(
                                 "actor '{}' has status {:?} as of '{}' (year {}-{}), \
                                  cannot participate in '{}' (year {}-{})",
-                                p.actor, status, change_event_id,
-                                change_time.start, change_time.end,
-                                event.id, event.time_span.start, event.time_span.end,
+                                p.actor,
+                                status,
+                                change_event_id,
+                                change_time.start,
+                                change_time.end,
+                                event.id,
+                                event.time_span.start,
+                                event.time_span.end,
                             ),
                         });
                     }
@@ -320,9 +367,14 @@ fn validate_state(chronicle: &Chronicle, config: &ValidationConfig, report: &mut
                             description: format!(
                                 "location '{}' has status {:?} as of '{}' (year {}-{}), \
                                  cannot host '{}' (year {}-{})",
-                                loc, status, change_event_id,
-                                change_time.start, change_time.end,
-                                event.id, event.time_span.start, event.time_span.end,
+                                loc,
+                                status,
+                                change_event_id,
+                                change_time.start,
+                                change_time.end,
+                                event.id,
+                                event.time_span.start,
+                                event.time_span.end,
                             ),
                         });
                     }
@@ -336,8 +388,14 @@ fn validate_state(chronicle: &Chronicle, config: &ValidationConfig, report: &mut
 
 fn validate_orphans(chronicle: &Chronicle, report: &mut ValidationReport) {
     for nx in chronicle.graph.node_indices() {
-        let in_deg = chronicle.graph.neighbors_directed(nx, Direction::Incoming).count();
-        let out_deg = chronicle.graph.neighbors_directed(nx, Direction::Outgoing).count();
+        let in_deg = chronicle
+            .graph
+            .neighbors_directed(nx, Direction::Incoming)
+            .count();
+        let out_deg = chronicle
+            .graph
+            .neighbors_directed(nx, Direction::Outgoing)
+            .count();
         if in_deg == 0 && out_deg == 0 {
             report.warnings.push(ValidationWarning::OrphanEntity {
                 entity_id: chronicle.graph[nx].id().to_owned(),
@@ -385,7 +443,10 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
         errors.push(ValidationError::DanglingReference {
             source_id: event.id.clone(),
             target_id: event.id.clone(),
-            context: format!("proposed event '{}' has the same ID as an existing entity", event.id),
+            context: format!(
+                "proposed event '{}' has the same ID as an existing entity",
+                event.id
+            ),
         });
     }
 
@@ -441,8 +502,12 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
                         event_id: event.id.clone(),
                         description: format!(
                             "proposed event '{}' (year {}-{}) precedes actor '{}' lifespan ({}-{})",
-                            event.id, event.time_span.start, event.time_span.end,
-                            actor.id, lifespan.start, lifespan.end,
+                            event.id,
+                            event.time_span.start,
+                            event.time_span.end,
+                            actor.id,
+                            lifespan.start,
+                            lifespan.end,
                         ),
                     });
                 }
@@ -472,8 +537,12 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
                     event_id: cause_event.id.clone(),
                     description: format!(
                         "proposed event '{}' (year {}-{}) precedes its cause '{}' (year {}-{})",
-                        event.id, event.time_span.start, event.time_span.end,
-                        cause_event.id, cause_event.time_span.start, cause_event.time_span.end,
+                        event.id,
+                        event.time_span.start,
+                        event.time_span.end,
+                        cause_event.id,
+                        cause_event.time_span.start,
+                        cause_event.time_span.end,
                     ),
                 });
             }
@@ -495,9 +564,14 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
                         description: format!(
                             "actor '{}' has status {:?} as of '{}' (year {}-{}), \
                              cannot participate in proposed event '{}' (year {}-{})",
-                            p.actor, status, change_event_id,
-                            change_time.start, change_time.end,
-                            event.id, event.time_span.start, event.time_span.end,
+                            p.actor,
+                            status,
+                            change_event_id,
+                            change_time.start,
+                            change_time.end,
+                            event.id,
+                            event.time_span.start,
+                            event.time_span.end,
                         ),
                     });
                 }
@@ -517,9 +591,14 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
                         description: format!(
                             "location '{}' has status {:?} as of '{}' (year {}-{}), \
                              cannot host proposed event '{}' (year {}-{})",
-                            loc, status, change_event_id,
-                            change_time.start, change_time.end,
-                            event.id, event.time_span.start, event.time_span.end,
+                            loc,
+                            status,
+                            change_event_id,
+                            change_time.start,
+                            change_time.end,
+                            event.id,
+                            event.time_span.start,
+                            event.time_span.end,
                         ),
                     });
                 }
@@ -527,5 +606,9 @@ pub fn can_add_event(chronicle: &Chronicle, event: &Event) -> Result<(), Vec<Val
         }
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }

--- a/tests/boundary_conditions.rs
+++ b/tests/boundary_conditions.rs
@@ -1,9 +1,9 @@
 //! Boundary-condition tests for validation edge cases (issue #2).
 
-use std::path::Path;
 use chronicle::graph::Chronicle;
 use chronicle::model::*;
 use chronicle::validation::ValidationError;
+use std::path::Path;
 
 fn load() -> Chronicle {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/world");
@@ -62,8 +62,10 @@ fn siege_of_silica_pattern_is_valid() {
     let silica_violations: Vec<_> = report.errors.iter().filter(|e| {
         matches!(e, ValidationError::StateViolation { entity_id, .. } if entity_id == "silica")
     }).collect();
-    assert!(silica_violations.is_empty(),
-        "siege_of_silica destroying silica during the event should not be a state violation");
+    assert!(
+        silica_violations.is_empty(),
+        "siege_of_silica destroying silica during the event should not be a state violation"
+    );
 }
 
 // ── Overlapping timespans with causal ordering ─────────────
@@ -74,12 +76,18 @@ fn overlapping_cause_and_effect_is_valid() {
     // revelation_of_matthias (15-15) causes great_divide (15-15) — same year
     // This is already in the data and should be valid
     let report = c.validate();
-    let causal_violations: Vec<_> = report.errors.iter().filter(|e| {
-        matches!(e, ValidationError::TemporalViolation { entity_id, event_id, .. }
+    let causal_violations: Vec<_> = report
+        .errors
+        .iter()
+        .filter(|e| {
+            matches!(e, ValidationError::TemporalViolation { entity_id, event_id, .. }
             if entity_id == "great_divide" && event_id == "revelation_of_matthias")
-    }).collect();
-    assert!(causal_violations.is_empty(),
-        "same-year cause and effect should not be a temporal violation");
+        })
+        .collect();
+    assert!(
+        causal_violations.is_empty(),
+        "same-year cause and effect should not be a temporal violation"
+    );
 }
 
 #[test]
@@ -112,11 +120,15 @@ fn actor_in_multiple_roles_across_events_is_valid() {
     // mirror_order participates in 4 events with different roles — should all be fine
     let c = load();
     let report = c.validate();
-    let mirror_violations: Vec<_> = report.errors.iter().filter(|e| {
-        matches!(e, ValidationError::StateViolation { entity_id, .. }
+    let mirror_violations: Vec<_> = report
+        .errors
+        .iter()
+        .filter(|e| {
+            matches!(e, ValidationError::StateViolation { entity_id, .. }
             | ValidationError::TemporalViolation { entity_id, .. }
             if entity_id == "mirror_order")
-    }).collect();
+        })
+        .collect();
     assert!(mirror_violations.is_empty());
 }
 

--- a/tests/can_add_event.rs
+++ b/tests/can_add_event.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
-use std::path::Path;
 use chronicle::graph::Chronicle;
 use chronicle::model::*;
 use chronicle::validation::ValidationError;
+use std::collections::HashSet;
+use std::path::Path;
 
 fn load() -> Chronicle {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/world");
@@ -47,8 +47,10 @@ fn rejects_duplicate_id() {
     let c = load();
     let event = make_event("siege_of_silica", 30, 30);
     let errs = c.can_add_event(&event).unwrap_err();
-    assert!(errs.iter().any(|e| matches!(e, ValidationError::DanglingReference { context, .. }
-        if context.contains("same ID"))));
+    assert!(errs.iter().any(
+        |e| matches!(e, ValidationError::DanglingReference { context, .. }
+        if context.contains("same ID"))
+    ));
 }
 
 // ── Dangling references ────────────────────────────────────
@@ -143,7 +145,13 @@ fn allows_captured_actor_by_default() {
 fn custom_config_captured_is_terminal() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/world");
     let config = ValidationConfig {
-        terminal_statuses: [Status::Dead, Status::Destroyed, Status::Dissolved, Status::Captured].into(),
+        terminal_statuses: [
+            Status::Dead,
+            Status::Destroyed,
+            Status::Dissolved,
+            Status::Captured,
+        ]
+        .into(),
     };
     let c = Chronicle::from_directory_with_config(&path, config).unwrap();
 
@@ -191,7 +199,11 @@ fn collects_all_errors_not_just_first() {
 
     let errs = c.can_add_event(&event).unwrap_err();
     // Should have at least 3 errors: dangling location, participant, and caused_by
-    assert!(errs.len() >= 3, "expected at least 3 errors, got {}", errs.len());
+    assert!(
+        errs.len() >= 3,
+        "expected at least 3 errors, got {}",
+        errs.len()
+    );
 }
 
 // ── Error messages are actionable ──────────────────────────
@@ -208,7 +220,10 @@ fn error_messages_contain_full_context() {
     // Should mention: the entity, the status, the causing event, years
     assert!(msg.contains("silica"), "should mention entity: {msg}");
     assert!(msg.contains("Destroyed"), "should mention status: {msg}");
-    assert!(msg.contains("siege_of_silica"), "should mention causing event: {msg}");
+    assert!(
+        msg.contains("siege_of_silica"),
+        "should mention causing event: {msg}"
+    );
     assert!(msg.contains("20"), "should mention year: {msg}");
     assert!(msg.contains("25"), "should mention proposed year: {msg}");
 }

--- a/tests/siege_of_silica.rs
+++ b/tests/siege_of_silica.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
 use chronicle::graph::Chronicle;
 use chronicle::model::*;
+use std::path::Path;
 
 fn load() -> Chronicle {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/world");
@@ -47,7 +47,9 @@ fn actor_query_kaine_durgan_events() {
 #[test]
 fn actor_query_brother_halix_events() {
     let c = load();
-    let halix = c.actor("brother_halix").expect("brother_halix should exist");
+    let halix = c
+        .actor("brother_halix")
+        .expect("brother_halix should exist");
     let events = halix.events();
     // Halix participates in purist_uprising and battle_of_broken_glass
     assert_eq!(events.len(), 2);
@@ -185,7 +187,10 @@ fn event_query_state_changes() {
     let changes = siege.state_changes();
     assert_eq!(changes.len(), 1);
     assert_eq!(changes[0].entity, "silica");
-    assert_eq!(changes[0].change, StateChange::StatusChange(Status::Destroyed));
+    assert_eq!(
+        changes[0].change,
+        StateChange::StatusChange(Status::Destroyed)
+    );
 }
 
 // ── Place queries ──────────────────────────────────────────
@@ -288,19 +293,28 @@ fn concept_loads_and_validates() {
     assert!(c.index.contains_key("null_field_technology"));
     // origin_event reference should resolve (no validation errors for it)
     let report = c.validate();
-    let concept_errors: Vec<_> = report.errors.iter().filter(|e| {
-        matches!(e, chronicle::validation::ValidationError::DanglingReference { source_id, .. }
+    let concept_errors: Vec<_> = report
+        .errors
+        .iter()
+        .filter(|e| {
+            matches!(e, chronicle::validation::ValidationError::DanglingReference { source_id, .. }
             if source_id == "null_field_technology")
-    }).collect();
+        })
+        .collect();
     assert!(concept_errors.is_empty());
 }
 
 #[test]
 fn concept_query_origin_event() {
     let c = load();
-    let nfg = c.concept("null_field_technology").expect("concept should exist");
+    let nfg = c
+        .concept("null_field_technology")
+        .expect("concept should exist");
     assert_eq!(nfg.data().name, "Null Field Generators");
-    assert_eq!(nfg.data().concept_type, chronicle::model::ConceptType::Technology);
+    assert_eq!(
+        nfg.data().concept_type,
+        chronicle::model::ConceptType::Technology
+    );
 
     let origin = nfg.origin_event().expect("should have origin event");
     assert_eq!(origin.id, "battle_of_broken_glass");

--- a/tests/subjective_fragments.rs
+++ b/tests/subjective_fragments.rs
@@ -1,8 +1,8 @@
 //! Phase 4: Subjective fragment queries (issue #4).
 
-use std::path::Path;
 use chronicle::graph::Chronicle;
 use chronicle::model::*;
+use std::path::Path;
 
 fn load() -> Chronicle {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/data/world");
@@ -64,11 +64,17 @@ fn filter_accounts_by_fidelity() {
     let c = load();
     let accounts = c.accounts_of("siege_of_silica");
 
-    let biased: Vec<_> = accounts.iter().filter(|a| a.fidelity == Fidelity::Biased).collect();
+    let biased: Vec<_> = accounts
+        .iter()
+        .filter(|a| a.fidelity == Fidelity::Biased)
+        .collect();
     assert_eq!(biased.len(), 1);
     assert_eq!(biased[0].source, "kaine_durgan");
 
-    let partial: Vec<_> = accounts.iter().filter(|a| a.fidelity == Fidelity::Partial).collect();
+    let partial: Vec<_> = accounts
+        .iter()
+        .filter(|a| a.fidelity == Fidelity::Partial)
+        .collect();
     assert_eq!(partial.len(), 1);
     assert_eq!(partial[0].source, "jorik_vane");
 }
@@ -80,7 +86,10 @@ fn accounts_mention_different_entities() {
     let c = load();
     let accounts = c.accounts_of("siege_of_silica");
 
-    let kaine_account = accounts.iter().find(|a| a.source == "kaine_durgan").unwrap();
+    let kaine_account = accounts
+        .iter()
+        .find(|a| a.source == "kaine_durgan")
+        .unwrap();
     let jorik_account = accounts.iter().find(|a| a.source == "jorik_vane").unwrap();
 
     let kaine_mentions: Vec<String> = chronicle::graph::parse_references(&kaine_account.text);
@@ -108,7 +117,11 @@ fn jorik_account_covers_multiple_events() {
     let jorik = &accounts[0];
     assert_eq!(jorik.event_refs.len(), 3);
     assert!(jorik.event_refs.contains(&"siege_of_silica".to_owned()));
-    assert!(jorik.event_refs.contains(&"battle_of_broken_glass".to_owned()));
+    assert!(
+        jorik
+            .event_refs
+            .contains(&"battle_of_broken_glass".to_owned())
+    );
     assert!(jorik.event_refs.contains(&"purist_uprising".to_owned()));
 }
 
@@ -122,5 +135,8 @@ fn jorik_vane_no_longer_orphan() {
         matches!(w, chronicle::validation::ValidationWarning::OrphanEntity { entity_id }
             if entity_id == "jorik_vane")
     });
-    assert!(!jorik_orphan, "jorik_vane should not be orphaned now that he has an account");
+    assert!(
+        !jorik_orphan,
+        "jorik_vane should not be orphaned now that he has an account"
+    );
 }

--- a/tests/validation_errors.rs
+++ b/tests/validation_errors.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
 use chronicle::graph::Chronicle;
 use chronicle::validation::{ValidationError, ValidationWarning};
+use std::path::Path;
 
 fn data_path(scenario: &str) -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -19,7 +19,10 @@ fn catches_dangling_reference() {
         matches!(e, ValidationError::DanglingReference { target_id, .. } if target_id == "nonexistent_actor")
     }).collect();
 
-    assert!(!dangling.is_empty(), "should catch dangling reference to nonexistent_actor");
+    assert!(
+        !dangling.is_empty(),
+        "should catch dangling reference to nonexistent_actor"
+    );
 }
 
 // ── Temporal violation (dead actor participates later) ──────
@@ -29,12 +32,19 @@ fn catches_state_violation_dead_actor() {
     let c = Chronicle::from_directory(&data_path("temporal_violation")).unwrap();
     let report = c.validate();
 
-    let violations: Vec<_> = report.errors.iter().filter(|e| {
-        matches!(e, ValidationError::StateViolation { entity_id, event_id, .. }
+    let violations: Vec<_> = report
+        .errors
+        .iter()
+        .filter(|e| {
+            matches!(e, ValidationError::StateViolation { entity_id, event_id, .. }
             if entity_id == "doomed_soldier" && event_id == "later_battle")
-    }).collect();
+        })
+        .collect();
 
-    assert!(!violations.is_empty(), "should catch dead actor participating in later event");
+    assert!(
+        !violations.is_empty(),
+        "should catch dead actor participating in later event"
+    );
 }
 
 // ── State violation (event at destroyed place) ─────────────
@@ -44,12 +54,19 @@ fn catches_state_violation_destroyed_place() {
     let c = Chronicle::from_directory(&data_path("state_violation")).unwrap();
     let report = c.validate();
 
-    let violations: Vec<_> = report.errors.iter().filter(|e| {
-        matches!(e, ValidationError::StateViolation { entity_id, event_id, .. }
+    let violations: Vec<_> = report
+        .errors
+        .iter()
+        .filter(|e| {
+            matches!(e, ValidationError::StateViolation { entity_id, event_id, .. }
             if entity_id == "ruined_city" && event_id == "impossible_market")
-    }).collect();
+        })
+        .collect();
 
-    assert!(!violations.is_empty(), "should catch event at destroyed location");
+    assert!(
+        !violations.is_empty(),
+        "should catch event at destroyed location"
+    );
 }
 
 // ── Orphan entity ──────────────────────────────────────────
@@ -63,14 +80,20 @@ fn catches_orphan_entity() {
         matches!(w, ValidationWarning::OrphanEntity { entity_id } if entity_id == "forgotten_hermit")
     }).collect();
 
-    assert!(!orphans.is_empty(), "should warn about orphaned forgotten_hermit");
+    assert!(
+        !orphans.is_empty(),
+        "should warn about orphaned forgotten_hermit"
+    );
 
     // connected_faction should NOT be orphaned (it participates in an event)
     let false_orphans: Vec<_> = report.warnings.iter().filter(|w| {
         matches!(w, ValidationWarning::OrphanEntity { entity_id } if entity_id == "connected_faction")
     }).collect();
 
-    assert!(false_orphans.is_empty(), "connected_faction should not be orphaned");
+    assert!(
+        false_orphans.is_empty(),
+        "connected_faction should not be orphaned"
+    );
 }
 
 // ── Duplicate ID ───────────────────────────────────────────
@@ -83,5 +106,8 @@ fn catches_duplicate_id() {
         Ok(_) => panic!("should fail to load duplicate IDs"),
     };
     let msg = err.to_string();
-    assert!(msg.contains("duplicate_id"), "error should mention the duplicate ID: {msg}");
+    assert!(
+        msg.contains("duplicate_id"),
+        "error should mention the duplicate ID: {msg}"
+    );
 }


### PR DESCRIPTION
Applies `cargo fmt` across all source and test files. No logic changes — purely cosmetic formatting (import ordering, line wrapping, struct literal expansion).

62 tests pass, 0 clippy warnings.